### PR TITLE
Fix htmlpreview link in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ memory
 
 Visualise your linker memory map file using D3.js. Try it out here:
 
-http://htmlpreview.github.com/?https://github.com/eliotstock/memory/blob/master/index.html
+https://htmlpreview.github.io/?https://github.com/eliotstock/memory/blob/master/index.html
 
 This has only been tested on a project for the Nordic nRF51822, but should work with any *.Map file produced by the GNU linker, ld.
 


### PR DESCRIPTION
The current link returns "404 There isn't a GitHub Pages site here."